### PR TITLE
Backend

### DIFF
--- a/backend/config/routes/authRoute.js
+++ b/backend/config/routes/authRoute.js
@@ -6,4 +6,6 @@ router.post("/login", controller.login);
 
 router.post("/", controller.registUser);
 
+router.get("/refresh_token", controller.refreshToken);
+
 module.exports = router;

--- a/backend/config/routes/indexRoute.js
+++ b/backend/config/routes/indexRoute.js
@@ -2,7 +2,7 @@ var express = require("express");
 var router = express.Router();
 
 /* GET home page. */
-router.get("/", async function (req, res, next) {
+router.get("/", function (req, res) {
   res.send("This is Home Page!");
 });
 

--- a/backend/controller/auth/index.js
+++ b/backend/controller/auth/index.js
@@ -1,7 +1,9 @@
 const login = require("./login");
 const registUser = require("./registUser");
+const refreshToken = require("./refreshToken");
 
 module.exports = {
   login,
   registUser,
+  refreshToken,
 };

--- a/backend/controller/auth/refreshToken.js
+++ b/backend/controller/auth/refreshToken.js
@@ -1,0 +1,54 @@
+/* IMPORTS */
+const jwt = require("../common/jwt");
+const logger = require("../../config/logger");
+
+/* METHODS */
+function verifyToken(refreshToken) {
+  logger.info(`[auth][refreshToken]-> verify token`);
+  return new Promise((resolve, reject) => {
+    jwt
+      .validate_refresh(refreshToken)
+      .then((payload) => {
+        resolve(payload);
+      })
+      .catch((error) => reject(error));
+  });
+}
+
+function generateToken(payload) {
+  logger.info(`[auth][refreshToken]-> generate new access token`);
+  return new Promise((resolve, reject) => {
+    jwt
+      .generate(payload)
+      .then((token) => {
+        resolve(token);
+      })
+      .catch((error) => reject(error));
+  });
+}
+
+/* EXPORTS */
+module.exports = async function (req, res) {
+  const { refreshToken } = req.cookies;
+  logger.info(`[auth][refreshToken]-> start`);
+  try {
+    const payload = await verifyToken(refreshToken);
+    const { userId, nickname, avatarUrl, statusMessage } = payload;
+    const accessToken = await generateToken({
+      userId,
+      nickname,
+      avatarUrl,
+      statusMessage,
+    });
+
+    logger.info(`[auth][refreshToken]-> done`);
+    res.send({ accessToken });
+  } catch (error) {
+    if (!error.status) {
+      logger.error(error);
+      res.status(500).send("알 수 없는 오류가 발생하였습니다.");
+    } else {
+      logger.info(`[auth][refreshToken]-> ${error.status}:${error.message}`);
+    }
+  }
+};


### PR DESCRIPTION
네 jwt 로직 수정합니다. 현황 정리하면

1. 로그인하면 access, refresh 둘 다 발급받음. access는 response.body에, refresh는 쿠키에
2. 로그인 후 기능들은 항상 헤더에 access_token 을 달아줘야 함
3. access_token 만료되면 (발급 후 15분) 404 받음. silence refresh 인지 머시긴지 해야함 (/auth/refresh_token)
4. /auth/refresh_token 은 요청만 하면 됨. 과자니까 :D
5. refresh token 확인되면 response body 에 새 토큰 태워보내줌. 그거 받아서 다시 헤더에 올려서 api 쓰면됨

네